### PR TITLE
Introduce support for client and worker socket options

### DIFF
--- a/libmdp/include/mdp_client.h
+++ b/libmdp/include/mdp_client.h
@@ -40,6 +40,12 @@ void
     mdp_client_destroy (mdp_client_t **self_p);
 void
     mdp_client_set_timeout (mdp_client_t *self, int timeout);
+int
+    mdp_client_setsockopt (mdp_client_t *self, int option, const void *optval,
+    size_t optvallen);
+int
+    mdp_client_getsockopt (mdp_client_t *self, int option, void *optval,
+    size_t *optvallen);
 void
     mdp_client_send (mdp_client_t *self, char *service, zmsg_t **request_p);
 zmsg_t *

--- a/libmdp/include/mdp_worker.h
+++ b/libmdp/include/mdp_worker.h
@@ -42,6 +42,12 @@ void
     mdp_worker_set_heartbeat (mdp_worker_t *self, int heartbeat);
 void
     mdp_worker_set_reconnect (mdp_worker_t *self, int reconnect);
+int
+    mdp_worker_setsockopt (mdp_worker_t *self, int option, const void *optval,
+    size_t optvallen);
+int
+    mdp_worker_getsockopt (mdp_worker_t *self, int option, void *optval,
+    size_t *optvallen);
 zmsg_t *
     mdp_worker_recv (mdp_worker_t *self, zframe_t **reply_p);
 void

--- a/libmdp/src/mdp_client.c
+++ b/libmdp/src/mdp_client.c
@@ -99,6 +99,30 @@ mdp_client_set_timeout (mdp_client_t *self, int timeout)
 }
 
 
+//  ---------------------------------------------------------------------
+//  Set client socket option
+
+int
+mdp_client_setsockopt (mdp_client_t *self, int option, const void *optval, size_t optvallen)
+{
+    assert (self);
+    assert (self->client);
+    return zmq_setsockopt (self->client, option, optval, optvallen);
+}
+
+
+//  ---------------------------------------------------------------------
+//  Get client socket option
+
+int
+mdp_client_getsockopt (mdp_client_t *self, 	int option, void *optval, size_t *optvallen)
+{
+    assert (self);
+    assert (self->client);
+    return zmq_getsockopt (self->client, option, optval, optvallen);
+}
+
+
 //  Here is the send method. It sends a request to the broker.
 //  It takes ownership of the request message, and destroys it when sent.
 

--- a/libmdp/src/mdp_worker.c
+++ b/libmdp/src/mdp_worker.c
@@ -165,6 +165,30 @@ mdp_worker_set_reconnect (mdp_worker_t *self, int reconnect)
 }
 
 
+//  ---------------------------------------------------------------------
+//  Set worker socket option
+
+int
+mdp_worker_setsockopt (mdp_worker_t *self, int option, const void *optval, size_t optvallen)
+{
+    assert (self);
+    assert (self->worker);
+    return zmq_setsockopt (self->worker, option, optval, optvallen);
+}
+
+
+//  ---------------------------------------------------------------------
+//  Get worker socket option
+
+int
+mdp_worker_getsockopt (mdp_worker_t *self, 	int option, void *optval, size_t *optvallen)
+{
+    assert (self);
+    assert (self->worker);
+    return zmq_getsockopt (self->worker, option, optval, optvallen);
+}
+
+
 //  This is the recv method; it receives a new request from a client.
 //  If reply_to_p is not NULL, a pointer to client's address is filled in.
 


### PR DESCRIPTION
Some language implementations ( eg. Ruby 1.8.x ) require access to ZMQ_EVENTS && ZMQ_FD socket options in order to make green threading work properly. Other socket options can be set / retrieved as well given the APIs just delegate to zmq_(get|set)sockopt() and clients and workers are on the edges and thus sock options should not affect the Majordomo implementation. 
