### PR TITLE
Added a Least Recently Used purging schema

### DIFF
--- a/libmdp/src/mdp_broker.c
+++ b/libmdp/src/mdp_broker.c
@@ -206,12 +206,12 @@ s_broker_worker_msg (broker_t *self, zframe_t *sender, zmsg_t *msg)
     else
     if (zframe_streq (command, MDPW_HEARTBEAT)) {
         if (worker_ready) {
-        	if (zlist_size (self->waiting) > 1) {
-				// Move worker to the end of the waiting queue,
-        		// so s_broker_purge will only check old worker(s)
-				zlist_remove (self->waiting, worker);
-				zlist_append (self->waiting, worker);
-        	}
+            if (zlist_size (self->waiting) > 1) {
+                // Move worker to the end of the waiting queue,
+                // so s_broker_purge will only check old worker(s)
+                zlist_remove (self->waiting, worker);
+                zlist_append (self->waiting, worker);
+            }
             worker->expiry = zclock_time () + HEARTBEAT_EXPIRY;
         }
         else


### PR DESCRIPTION
When calling s_broker_purge, always the first worker is checked for expiration. If that one never times out or disconnects, no workers will be purged.
To make sure newer workers can timeout too, we need to move fresh workers to the end of the broker's waiting list. Only if there is more than one worker of course.
