### PR TITLE
Use zframe_destroy() to free zframe_t

### DIFF
--- a/libmdp/src/mdp_broker.c
+++ b/libmdp/src/mdp_broker.c
@@ -224,7 +224,7 @@ s_broker_worker_msg (broker_t *self, zframe_t *sender, zmsg_t *msg)
         zclock_log ("E: invalid input message");
         zmsg_dump (msg);
     }
-    free (command);
+    zframe_destroy (&command);
     zmsg_destroy (&msg);
 }
 


### PR DESCRIPTION
This patch fixes #19
