### PR TITLE
Disconnecting worker from broker

### DIFF
--- a/libmdp/src/mdp_worker.c
+++ b/libmdp/src/mdp_worker.c
@@ -119,6 +119,11 @@ mdp_worker_new (char *broker,char *service, int verbose)
     self->heartbeat = 2500;     //  msecs
     self->reconnect = 2500;     //  msecs
 
+    // A non-zero linger value is required for DISCONNECT to be sent
+    // when the worker is destroyed.  100 is arbitrary but chosen to be
+    // sufficient for common cases without significant delay in broken ones.
+    zctx_set_linger (self->ctx, 100);
+
     s_mdp_worker_connect_to_broker (self);
     return self;
 }
@@ -155,6 +160,16 @@ void
 mdp_worker_set_heartbeat (mdp_worker_t *self, int heartbeat)
 {
     self->heartbeat = heartbeat;
+}
+
+
+//  ---------------------------------------------------------------------
+//  Set linger time
+
+void
+mdp_worker_set_linger (mdp_worker_t *self, int linger)
+{
+    zctx_set_linger (self->ctx, linger);
 }
 
 


### PR DESCRIPTION
This pull request fixes #45 by sending DISCONNECT when the worker is destroyed and adding a linger time to ensure the DISCONNECT is actually transmitted.

Unfortunately, although this does address the specific issue of #45, it doesn't address the more fundamental issue of how to "cleanly" disconnect from a broker without losing any requests.  At any point the worker calls `mdp_worker_destroy` there may be more requests which have been sent, or are being sent by the broker, that will be discarded.  However, I don't see a way to work around this without adding some sort of advisory disconnect message to the protocol (semantically "I am going to disconnect once I finish currently queued requests, stop sending me more requests").  However, that being said, I think these commits are a step in the right direction.
